### PR TITLE
Allow connections to remote servers

### DIFF
--- a/src/main/kotlin/gtlp/groundmc/lobby/LobbyMain.kt
+++ b/src/main/kotlin/gtlp/groundmc/lobby/LobbyMain.kt
@@ -62,7 +62,9 @@ class LobbyMain : JavaPlugin() {
         upgradeConfig()
         loadConfig()
         logger.finer("Loading database...")
-        Database.connect("jdbc:h2:" + dataFolder.absolutePath + "/database", driver = "org.h2.Driver")
+        Database.connect(config.getString("database.url")
+                .replace("\$dataFolder", dataFolder.absolutePath)
+                , config.getString("database.driver"), config.getString("database.username", ""), config.getString("database.password", ""))
         transaction {
             createMissingTablesAndColumns(Meta, Users, Relationships)
             Meta.upgradeDatabase()
@@ -96,12 +98,23 @@ class LobbyMain : JavaPlugin() {
 
     private fun loadConfig() {
         logger.entering(LobbyMain::class, "loadConfig")
+
         config.addDefault("inventory.content", listOf<ItemStack>())
+
         config.addDefault("hub", Bukkit.getWorlds().first().spawnLocation)
+
         config.addDefault("coins.dailyAmount", 100)
+
         config.addDefault("log.verbosity", "FINEST")
+
         config.addDefault("slowchat.enabled", true)
         config.addDefault("slowchat.timeout", 5)
+
+        config.addDefault("database.username", "")
+        config.addDefault("database.password", "")
+        config.addDefault("database.driver", "org.h2.Driver")
+        config.addDefault("database.url", "jdbc:h2:\$dataFolder/database")
+
         config.options().copyDefaults(true)
         saveDefaultConfig()
         if ("inventory.content" in config && config["inventory.content"] is List<*>) {

--- a/src/main/kotlin/gtlp/groundmc/lobby/database/table/Users.kt
+++ b/src/main/kotlin/gtlp/groundmc/lobby/database/table/Users.kt
@@ -15,7 +15,7 @@ import java.util.*
  */
 object Users : Table() {
     val id = uuid("playerId").primaryKey().uniqueIndex()
-    val lastName = text("last_name").default("<no name>")
+    val lastName = text("last_name")
     val silentStatus = bool("silent_status").default(false)
     val hiddenStatus = enumeration("hidden_status", VisibilityStates::class.java).default(VisibilityStates.ALL)
     val vanishStatus = bool("vanish_status").default(false)

--- a/src/main/kotlin/gtlp/groundmc/lobby/event/PlayerEventListener.kt
+++ b/src/main/kotlin/gtlp/groundmc/lobby/event/PlayerEventListener.kt
@@ -74,6 +74,7 @@ class PlayerEventListener : Listener {
             if (Users.select { Users.id.eq(player.uniqueId) }.count() == 0) {
                 Users.insert {
                     it[Users.id] = player.uniqueId
+                    it[Users.lastName] = player.name
                 }
             }
             val inventory = player.inventory

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -16,3 +16,16 @@ slowchat:
 # For the numbers to put here, see this: https://docs.oracle.com/javase/7/docs/api/java/util/logging/Level.html
 log:
   verbosity: 0
+
+# Database connection information
+# Uses an in-memory database by default.
+# This database is saved in a file next to this config file by default.
+#
+# The following substitutions are available:
+#
+# $dataFolder     -     Is replaced with the absolute path of the data folder of this plugin at runtime
+database:
+  username:
+  driver: org.h2.Driver
+  password:
+  url: jdbc:h2:$dataFolder/database


### PR DESCRIPTION
Allow configurable remote servers to be used as database servers.

Known to work with H2, other databases might experience issues (please report them).

Closes #9 