### PR TITLE
Don't save filler items

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,0 @@
-[submodule "Item-NBT-API"]
-	path = Item-NBT-API
-	url = https://github.com/tr7zw/Item-NBT-API
-[submodule "Exposed"]
-	path = Exposed
-	url = https://github.com/jetbrains/Exposed
-[submodule "h2database"]
-	path = h2database
-	url = https://github.com/h2database/h2database

--- a/src/main/kotlin/gtlp/groundmc/lobby/Items.kt
+++ b/src/main/kotlin/gtlp/groundmc/lobby/Items.kt
@@ -46,7 +46,9 @@ object Items {
             nbtItem.displayName = I18n.getString("visibility.all")
             return nbtItem
         }
-    val FILLER: NBTItemExt = NBTItemExt(ItemStack(Material.STAINED_GLASS_PANE, 1, DyeColor.SILVER.woolData.toShort())).apply {
-        displayName = " "
-    }
+
+    val FILLER: NBTItemExt
+        get() = NBTItemExt(ItemStack(Material.STAINED_GLASS_PANE, 1, DyeColor.SILVER.woolData.toShort())).apply {
+            displayName = " "
+        }
 }

--- a/src/main/kotlin/gtlp/groundmc/lobby/LobbyMain.kt
+++ b/src/main/kotlin/gtlp/groundmc/lobby/LobbyMain.kt
@@ -1,6 +1,5 @@
 package gtlp.groundmc.lobby
 
-import com.google.gson.Gson
 import com.google.gson.GsonBuilder
 import de.tr7zw.itemnbtapi.NBTReflectionUtil
 import gtlp.groundmc.lobby.commands.*
@@ -14,8 +13,8 @@ import gtlp.groundmc.lobby.event.PlayerEventListener
 import gtlp.groundmc.lobby.inventory.LobbyInventory
 import gtlp.groundmc.lobby.inventory.LobbyInventoryHolder
 import gtlp.groundmc.lobby.registry.LobbyCommandRegistry
-import gtlp.groundmc.lobby.util.*
 import gtlp.groundmc.lobby.task.*
+import gtlp.groundmc.lobby.util.*
 import org.bukkit.Bukkit
 import org.bukkit.Difficulty
 import org.bukkit.Location
@@ -90,15 +89,13 @@ class LobbyMain : JavaPlugin() {
 
     private fun registerGsonHandlers() {
         logger.entering(LobbyMain::class, "registerGsonHandlers")
-        val fClass = NBTReflectionUtil::class.java
-        val fGson = fClass.getDeclaredField("gson")
+        val fGson = NBTReflectionUtil::class.java.getDeclaredField("gson")
         fGson.isAccessible = true
 
         val modifiersField = Field::class.java.getDeclaredField("modifiers")
         modifiersField.isAccessible = true
         modifiersField.setInt(fGson, fGson.modifiers and Modifier.FINAL.inv())
 
-        val gson = fGson.get(null) as Gson
         fGson.set(null, GsonBuilder().apply {
             registerTypeAdapter(Location::class.java, LocationTypeAdapter)
         }.create())
@@ -188,6 +185,13 @@ class LobbyMain : JavaPlugin() {
         logger.info("Saving configuration and disabling...")
         saveConfig()
         logger.exiting(LobbyMain::class, "onDisable")
+    }
+
+    override fun saveConfig() {
+        logger.entering(LobbyMain::class, "saveConfig")
+        config["inventory.content"] = LobbyInventory.TEMPLATE_INVENTORY.contents.map { if (it == Items.FILLER.item) null else it }
+        super.saveConfig()
+        logger.exiting(LobbyMain::class, "saveConfig")
     }
 
     override fun onCommand(sender: CommandSender, command: Command, label: String, args: Array<String>?): Boolean {


### PR DESCRIPTION
Makes filler items being saved as null (that's how they are created).

Cleans up the config file by reducing size and long entries.
Also allows us to change the filler when needed.
Lastly, refactor the code a bit and remove redundant files.

Closes #19 