### PR TITLE
Move from H2 to SQLite

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -50,18 +50,6 @@
 
     <dependencies>
         <dependency>
-            <groupId>joda-time</groupId>
-            <artifactId>joda-time</artifactId>
-            <version>2.9.9</version>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>com.h2database</groupId>
-            <artifactId>h2</artifactId>
-            <version>1.4.196</version>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
             <groupId>org.jetbrains.exposed</groupId>
             <artifactId>exposed</artifactId>
             <version>0.8.8</version>

--- a/src/main/kotlin/gtlp/groundmc/lobby/LobbyMain.kt
+++ b/src/main/kotlin/gtlp/groundmc/lobby/LobbyMain.kt
@@ -27,11 +27,13 @@ import org.bukkit.scheduler.BukkitScheduler
 import org.jetbrains.exposed.sql.Database
 import org.jetbrains.exposed.sql.SchemaUtils.createMissingTablesAndColumns
 import org.jetbrains.exposed.sql.exposedLogger
+import org.jetbrains.exposed.sql.transactions.TransactionManager
 import org.jetbrains.exposed.sql.transactions.transaction
 import org.slf4j.impl.JDK14LoggerAdapter
 import java.io.File
 import java.lang.reflect.Field
 import java.lang.reflect.Modifier
+import java.sql.Connection
 import java.util.*
 import java.util.logging.FileHandler
 import java.util.logging.Level
@@ -81,6 +83,9 @@ class LobbyMain : JavaPlugin() {
                 .replace("\$dataFolder", dataFolder.absolutePath),
                 config.getString("database.driver"), config.getString("database.username", ""),
                 config.getString("database.password", ""))
+        if (config.getString("database.driver") == "org.sqlite.JDBC") {
+            TransactionManager.manager.defaultIsolationLevel = Connection.TRANSACTION_SERIALIZABLE
+        }
         transaction {
             createMissingTablesAndColumns(Meta, Users, Relationships)
             Meta.upgradeDatabase()

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -25,14 +25,14 @@ log:
 #
 # $dataFolder     -     Is replaced with the absolute path of the data folder of this plugin at runtime
 #
-# The default driver is for the H2 database file.
+# The default driver is for the SQLite database file.
 # To use MySQL, use com.mysql.jdbc.Driver and fill in the url as described here:
 # https://dev.mysql.com/doc/connector-j/5.1/en/connector-j-reference-configuration-properties.html
 database:
   username:
-  driver: org.h2.Driver
+  driver: org.sqlite.JDBC
   password:
-  url: jdbc:h2:$dataFolder/database
+  url: jdbc:sqlite:$dataFolder/database
 
 # Version
 # The version of this config.

--- a/src/main/resources/dependencies.conf
+++ b/src/main/resources/dependencies.conf
@@ -1,6 +1,5 @@
 repository=bintray-kotlin-exposed:https://dl.bintray.com/kotlin/exposed
 artifact=joda-time:joda-time:2.9.9
-artifact=com.h2database:h2:1.4.196
 artifact=org.jetbrains.exposed:exposed:0.8
 artifact=org.jetbrains.kotlin:kotlin-stdlib:1.1.2-5
 artifact=org.jetbrains.kotlin:kotlin-stdlib-jre8:1.1.2-5


### PR DESCRIPTION
Removes H2 as it is not used as the default file-based database anymore.
(You shouldn't use a file-based database, but it's here to make sure the plugin works regardless of infrastructure)

Closes #47 