### PR TITLE
Remove join and quit messages.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,24 @@
+pipeline {
+  agent any
+  tools {
+        maven 'Maven3'
+        jdk 'Java8'
+  }
+  stages {
+    stage('Build') {
+      steps {
+        sh 'mvn clean test package'
+      }
+      post {
+        success {
+          junit 'target/surefire-reports/**/*.xml'
+        }
+      }
+    }
+    stage('Archive') {
+      steps {
+        archiveArtifacts artifacts: 'target/*.jar', excludes: 'target/original*'
+      }
+    }
+  }
+}

--- a/src/main/kotlin/gtlp/groundmc/lobby/event/listener/PreventWorldInteractionListener.kt
+++ b/src/main/kotlin/gtlp/groundmc/lobby/event/listener/PreventWorldInteractionListener.kt
@@ -5,6 +5,7 @@ import gtlp.groundmc.lobby.enums.NBTIdentifier
 import org.bukkit.event.EventHandler
 import org.bukkit.event.EventPriority
 import org.bukkit.event.Listener
+import org.bukkit.event.block.BlockBreakEvent
 import org.bukkit.event.block.BlockPlaceEvent
 import org.bukkit.event.entity.EntityPickupItemEvent
 import org.bukkit.event.player.PlayerDropItemEvent
@@ -49,6 +50,18 @@ object PreventWorldInteractionListener : Listener {
     @EventHandler(priority = EventPriority.LOWEST)
     fun preventItemPickup(event: EntityPickupItemEvent) {
         if (event.entity.world == LobbyMain.hubLocation.world) {
+            event.isCancelled = true
+        }
+    }
+
+    /**
+     * Prevents non-admin players from breaking blocks in the hub.
+     *
+     * @param event the event to handle
+     */
+    @EventHandler(priority = EventPriority.LOWEST)
+    fun preventBlockBreaking(event: BlockBreakEvent) {
+        if (event.player.world == LobbyMain.hubLocation.world) {
             event.isCancelled = true
         }
     }

--- a/src/main/kotlin/gtlp/groundmc/lobby/event/listener/PreventWorldInteractionListener.kt
+++ b/src/main/kotlin/gtlp/groundmc/lobby/event/listener/PreventWorldInteractionListener.kt
@@ -2,6 +2,8 @@ package gtlp.groundmc.lobby.event.listener
 
 import gtlp.groundmc.lobby.LobbyMain
 import gtlp.groundmc.lobby.enums.NBTIdentifier
+import gtlp.groundmc.lobby.enums.Permission
+import gtlp.groundmc.lobby.util.hasPermission
 import org.bukkit.event.EventHandler
 import org.bukkit.event.EventPriority
 import org.bukkit.event.Listener
@@ -61,7 +63,8 @@ object PreventWorldInteractionListener : Listener {
      */
     @EventHandler(priority = EventPriority.LOWEST)
     fun preventBlockBreaking(event: BlockBreakEvent) {
-        if (event.player.world == LobbyMain.hubLocation.world) {
+        if (event.player.world == LobbyMain.hubLocation.world
+                && event.player.hasPermission(Permission.ADMIN)) {
             event.isCancelled = true
         }
     }

--- a/src/main/kotlin/gtlp/groundmc/lobby/event/listener/PreventWorldInteractionListener.kt
+++ b/src/main/kotlin/gtlp/groundmc/lobby/event/listener/PreventWorldInteractionListener.kt
@@ -45,7 +45,7 @@ object PreventWorldInteractionListener : Listener {
     }
 
     /**
-     * Prevents players from picking up items when they are in the hub.
+     * Prevents non-admin players from picking up items when they are in the hub.
      *
      * @param event the event to handle
      */

--- a/src/main/kotlin/gtlp/groundmc/lobby/event/listener/PreventWorldInteractionListener.kt
+++ b/src/main/kotlin/gtlp/groundmc/lobby/event/listener/PreventWorldInteractionListener.kt
@@ -51,7 +51,8 @@ object PreventWorldInteractionListener : Listener {
      */
     @EventHandler(priority = EventPriority.LOWEST)
     fun preventItemPickup(event: EntityPickupItemEvent) {
-        if (event.entity.world == LobbyMain.hubLocation.world) {
+        if (event.entity.world == LobbyMain.hubLocation.world
+                && !event.entity.hasPermission(Permission.ADMIN)) {
             event.isCancelled = true
         }
     }
@@ -64,7 +65,7 @@ object PreventWorldInteractionListener : Listener {
     @EventHandler(priority = EventPriority.LOWEST)
     fun preventBlockBreaking(event: BlockBreakEvent) {
         if (event.player.world == LobbyMain.hubLocation.world
-                && event.player.hasPermission(Permission.ADMIN)) {
+                && !event.player.hasPermission(Permission.ADMIN)) {
             event.isCancelled = true
         }
     }

--- a/src/main/kotlin/gtlp/groundmc/lobby/event/listener/ServerStateListener.kt
+++ b/src/main/kotlin/gtlp/groundmc/lobby/event/listener/ServerStateListener.kt
@@ -100,11 +100,13 @@ object ServerStateListener : Listener {
 
     /**
      * Handles a player joining the server.
+     * Removes any message that should be sent on joining the server.
      *
      * @param event the event to handle
      */
     @EventHandler(priority = EventPriority.LOWEST)
     fun onPlayerLogin(event: PlayerJoinEvent) {
+        event.joinMessage = null
         transaction {
             if (Users.select { Users.id eq event.player.uniqueId }.count() == 0) {
                 Users.insert {
@@ -146,11 +148,13 @@ object ServerStateListener : Listener {
 
     /**
      * Cleans up when a player leaves the server.
+     * Removes any message that should be sent on joining the server.
      *
      * @param event the event to handle
      */
     @EventHandler(priority = EventPriority.LOWEST)
     fun onPlayerLogout(event: PlayerQuitEvent) {
+        event.quitMessage = null
         if (event.player.world == LobbyMain.hubLocation.world) {
             event.player.inventory.contents = LobbyMain.originalInventories[event.player]
         }


### PR DESCRIPTION
This removes join and quit messages.

This also prevents players from breaking blocks in the hub unless they have admin permissions.